### PR TITLE
Add basic HTTP server for online Battleship play

### DIFF
--- a/GopalBattleShip/Entities/Games/Game.cs
+++ b/GopalBattleShip/Entities/Games/Game.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using GopalBattleship.Entities.Boards;
 
 namespace GopalBattleship.Entities.Games
 {
@@ -10,6 +11,14 @@ namespace GopalBattleship.Entities.Games
     {
         public Player FirstPlayer { get; set; }
         public Player SecondPlayer { get; set; }
+        public Player CurrentPlayer { get; private set; }
+        public bool IsFinished
+        {
+            get
+            {
+                return FirstPlayer.HasLost || SecondPlayer.HasLost;
+            }
+        }
 
         public Game(string firstPlayer, string secondPlayer)
         {
@@ -19,8 +28,62 @@ namespace GopalBattleship.Entities.Games
             FirstPlayer.PlaceShips();
             SecondPlayer.PlaceShips();
 
-            FirstPlayer.OutputBoards();
-            SecondPlayer.OutputBoards();
+            CurrentPlayer = FirstPlayer;
+        }
+
+        public ShotResult FireShot(string playerName, Coordinates coordinates)
+        {
+            if (IsFinished)
+            {
+                throw new InvalidOperationException("Game already finished");
+            }
+
+            Player shootingPlayer;
+            Player opponent;
+
+            if (FirstPlayer.Name == playerName)
+            {
+                shootingPlayer = FirstPlayer;
+                opponent = SecondPlayer;
+            }
+            else if (SecondPlayer.Name == playerName)
+            {
+                shootingPlayer = SecondPlayer;
+                opponent = FirstPlayer;
+            }
+            else
+            {
+                throw new ArgumentException("Unknown player");
+            }
+
+            if (shootingPlayer != CurrentPlayer)
+            {
+                throw new InvalidOperationException("It's not this player's turn");
+            }
+
+            var result = opponent.ProcessShot(coordinates);
+            shootingPlayer.ProcessShotResult(coordinates, result);
+
+            if (!opponent.HasLost)
+            {
+                CurrentPlayer = opponent;
+            }
+
+            return result;
+        }
+
+        public string GetBoards(string playerName)
+        {
+            if (FirstPlayer.Name == playerName)
+            {
+                return FirstPlayer.GetBoardsString();
+            }
+            else if (SecondPlayer.Name == playerName)
+            {
+                return SecondPlayer.GetBoardsString();
+            }
+
+            throw new ArgumentException("Unknown player");
         }
 
         public void PlayTurn()
@@ -45,9 +108,6 @@ namespace GopalBattleship.Entities.Games
             {
                 PlayTurn();
             }
-
-            FirstPlayer.OutputBoards();
-            SecondPlayer.OutputBoards();
 
             if (FirstPlayer.HasLost)
             {

--- a/GopalBattleShip/Entities/Player.cs
+++ b/GopalBattleShip/Entities/Player.cs
@@ -4,6 +4,7 @@ using GopalBattleship.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 namespace GopalBattleship.Entities
 {
@@ -37,22 +38,32 @@ namespace GopalBattleship.Entities
         /// </summary>
         public void OutputBoards()
         {
-            Console.WriteLine(Name);
-            Console.WriteLine("Own Board:                          Firing Board:");
-            for(int row = 1; row <= 10; row++)
+            Console.WriteLine(GetBoardsString());
+        }
+
+        /// <summary>
+        /// Builds a string representation of both the game and firing boards.
+        /// </summary>
+        public string GetBoardsString()
+        {
+            StringBuilder builder = new StringBuilder();
+            builder.AppendLine(Name);
+            builder.AppendLine("Own Board:                          Firing Board:");
+            for (int row = 1; row <= 10; row++)
             {
-                for(int ownColumn = 1; ownColumn <= 10; ownColumn++)
+                for (int ownColumn = 1; ownColumn <= 10; ownColumn++)
                 {
-                    Console.Write(GameBoard.Panels.At(row, ownColumn).Status + " ");
+                    builder.Append(GameBoard.Panels.At(row, ownColumn).Status + " ");
                 }
-                Console.Write("                ");
+                builder.Append("                ");
                 for (int firingColumn = 1; firingColumn <= 10; firingColumn++)
                 {
-                    Console.Write(FiringBoard.Panels.At(row, firingColumn).Status + " ");
+                    builder.Append(FiringBoard.Panels.At(row, firingColumn).Status + " ");
                 }
-                Console.WriteLine(Environment.NewLine);
+                builder.AppendLine();
             }
-            Console.WriteLine(Environment.NewLine);
+            builder.AppendLine();
+            return builder.ToString();
         }
 
         /// <summary>

--- a/GopalBattleShip/GopalBattleship.csproj
+++ b/GopalBattleShip/GopalBattleship.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Entities\Player.cs" />
     <Compile Include="Entities\Ships\Battleship.cs" />
     <Compile Include="Entities\Ships\Ship.cs" />
+    <Compile Include="Online\OnlineGameServer.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/GopalBattleShip/Online/OnlineGameServer.cs
+++ b/GopalBattleShip/Online/OnlineGameServer.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Text;
+using GopalBattleship.Entities.Boards;
+using GopalBattleship.Entities.Games;
+
+namespace GopalBattleship.Online
+{
+    /// <summary>
+    /// Simple HTTP server to allow playing Battleship over the network.
+    /// </summary>
+    public class OnlineGameServer
+    {
+        private readonly HttpListener _listener;
+        private readonly ConcurrentDictionary<string, Game> _games = new ConcurrentDictionary<string, Game>();
+
+        public OnlineGameServer(string prefix)
+        {
+            _listener = new HttpListener();
+            _listener.Prefixes.Add(prefix);
+        }
+
+        public void Start()
+        {
+            _listener.Start();
+            _listener.BeginGetContext(ProcessRequest, null);
+            Console.WriteLine("Battleship server started on " + string.Join(", ", _listener.Prefixes));
+        }
+
+        public void Stop()
+        {
+            _listener.Stop();
+        }
+
+        private void ProcessRequest(IAsyncResult ar)
+        {
+            if (!_listener.IsListening) return;
+            var context = _listener.EndGetContext(ar);
+            _listener.BeginGetContext(ProcessRequest, null);
+
+            var request = context.Request;
+            var response = context.Response;
+            string payload = string.Empty;
+
+            try
+            {
+                if (request.Url.AbsolutePath == "/start")
+                {
+                    var player1 = request.QueryString["player1"];
+                    var player2 = request.QueryString["player2"];
+                    var id = Guid.NewGuid().ToString();
+                    _games[id] = new Game(player1, player2);
+                    payload = id;
+                }
+                else if (request.Url.AbsolutePath == "/fire")
+                {
+                    var id = request.QueryString["gameId"];
+                    var player = request.QueryString["player"];
+                    var rowStr = request.QueryString["row"];
+                    var colStr = request.QueryString["col"];
+
+                    if (_games.TryGetValue(id, out var game) &&
+                        int.TryParse(rowStr, out var row) &&
+                        int.TryParse(colStr, out var col))
+                    {
+                        var result = game.FireShot(player, new Coordinates(row, col));
+                        payload = result.ToString();
+                    }
+                    else
+                    {
+                        response.StatusCode = 400;
+                        payload = "Invalid request";
+                    }
+                }
+                else if (request.Url.AbsolutePath == "/board")
+                {
+                    var id = request.QueryString["gameId"];
+                    var player = request.QueryString["player"];
+                    if (_games.TryGetValue(id, out var game))
+                    {
+                        payload = game.GetBoards(player);
+                    }
+                    else
+                    {
+                        response.StatusCode = 404;
+                        payload = "Game not found";
+                    }
+                }
+                else
+                {
+                    response.StatusCode = 404;
+                    payload = "Unknown endpoint";
+                }
+            }
+            catch (Exception ex)
+            {
+                response.StatusCode = 500;
+                payload = ex.Message;
+            }
+
+            var buffer = Encoding.UTF8.GetBytes(payload);
+            response.ContentLength64 = buffer.Length;
+            response.OutputStream.Write(buffer, 0, buffer.Length);
+            response.OutputStream.Close();
+        }
+    }
+}

--- a/GopalBattleShip/Program.cs
+++ b/GopalBattleShip/Program.cs
@@ -1,6 +1,5 @@
-﻿using GopalBattleship.Entities.Games;
-using GopalBattleship.Utilities;
 using System;
+using GopalBattleship.Online;
 
 namespace GopalBattleship
 {
@@ -8,35 +7,12 @@ namespace GopalBattleship
     {
         static void Main(string[] args)
         {
-            int isFirstPlayerWinner = 0, isSecondPlayerWinner = 0;
-
-            Console.WriteLine("Specify the number of games you would like to play");
-            var numGames = Helpers.GetNumberOfGames();
-            Console.WriteLine($"Total number of games : {numGames}");
-            //Two players created
-            string firstPlayer = Helpers.GetPlayerName("first");
-            string secondPlayer = Helpers.GetPlayerName("second");
-            Console.Write("Enter any key to start :");
-            Console.ReadKey();
-
-            for (int i = 0; i < numGames; i++)
-            {
-                Game game1 = new Game(firstPlayer, secondPlayer);
-                game1.ExecuteTheWholeGame();
-                if(game1.FirstPlayer.HasLost)
-                {
-                    isSecondPlayerWinner++;
-                }
-                else
-                {
-                    isFirstPlayerWinner++;
-                }
-            }
-
-            Console.WriteLine($"{firstPlayer} Wins: " + isFirstPlayerWinner.ToString());
-            Console.WriteLine($"{secondPlayer} Wins: " + isSecondPlayerWinner.ToString());
+            var server = new OnlineGameServer("http://localhost:5000/");
+            server.Start();
+            Console.WriteLine("Battleship online server running at http://localhost:5000/");
+            Console.WriteLine("Press Enter to stop the server.");
             Console.ReadLine();
-           
+            server.Stop();
         }
     }
 }


### PR DESCRIPTION
## Summary
- add HTTP server to expose `/start`, `/fire`, and `/board` endpoints for remote play
- allow players to request board views and alternate turns via network
- start server from `Program.Main`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893f4a369688331a3845a4dbe783589