### PR TITLE
Add deploy-friendly server prefix and health endpoint; expand fleet, centralize board size, and harden gameplay validation

### DIFF
--- a/GopalBattleShip/Entities/Boards/Panel.cs
+++ b/GopalBattleShip/Entities/Boards/Panel.cs
@@ -34,7 +34,7 @@ namespace GopalBattleship.Entities.Boards
         {
             get
             {
-                return OccupationType == EnumLabel.Battleship;
+                return OccupationType.IsShip();
             }
         }
 

--- a/GopalBattleShip/Entities/Boards/PlayBoard.cs
+++ b/GopalBattleShip/Entities/Boards/PlayBoard.cs
@@ -11,14 +11,15 @@ namespace GopalBattleship.Entities.Boards
     /// </summary>
     public class PlayBoard
     {
+        public const int BoardSize = 10;
         public List<Panel> Panels { get; set; }
 
         public PlayBoard()
         {
             Panels = new List<Panel>();
-            for (int i = 1; i <= 10; i++)
+            for (int i = 1; i <= BoardSize; i++)
             {
-                for (int j = 1; j <= 10; j++)
+                for (int j = 1; j <= BoardSize; j++)
                 {
                     Panels.Add(new Panel(i, j));
                 }

--- a/GopalBattleShip/Entities/Boards/ShootingBoard.cs
+++ b/GopalBattleShip/Entities/Boards/ShootingBoard.cs
@@ -38,11 +38,11 @@ namespace GopalBattleship.Entities.Boards
             {
                 panels.Add(Panels.At(row - 1, column));
             }
-            if (row < 10)
+            if (row < BoardSize)
             {
                 panels.Add(Panels.At(row + 1, column));
             }
-            if (column < 10)
+            if (column < BoardSize)
             {
                 panels.Add(Panels.At(row, column + 1));
             }

--- a/GopalBattleShip/Entities/Games/Game.cs
+++ b/GopalBattleShip/Entities/Games/Game.cs
@@ -38,6 +38,12 @@ namespace GopalBattleship.Entities.Games
                 throw new InvalidOperationException("Game already finished");
             }
 
+            if (coordinates.Row < 1 || coordinates.Row > PlayBoard.BoardSize ||
+                coordinates.Column < 1 || coordinates.Column > PlayBoard.BoardSize)
+            {
+                throw new ArgumentOutOfRangeException(nameof(coordinates), "Shot coordinates are out of bounds.");
+            }
+
             Player shootingPlayer;
             Player opponent;
 

--- a/GopalBattleShip/Entities/Player.cs
+++ b/GopalBattleShip/Entities/Player.cs
@@ -27,7 +27,11 @@ namespace GopalBattleship.Entities
             Name = name;
             Ships = new List<Ship>()
             {
-                new Battleship()
+                new Carrier(),
+                new Battleship(),
+                new Cruiser(),
+                new Submarine(),
+                new Destroyer()
             };
             GameBoard = new PlayBoard();
             FiringBoard = new ShootingBoard();
@@ -49,14 +53,14 @@ namespace GopalBattleship.Entities
             StringBuilder builder = new StringBuilder();
             builder.AppendLine(Name);
             builder.AppendLine("Own Board:                          Firing Board:");
-            for (int row = 1; row <= 10; row++)
+            for (int row = 1; row <= PlayBoard.BoardSize; row++)
             {
-                for (int ownColumn = 1; ownColumn <= 10; ownColumn++)
+                for (int ownColumn = 1; ownColumn <= PlayBoard.BoardSize; ownColumn++)
                 {
                     builder.Append(GameBoard.Panels.At(row, ownColumn).Status + " ");
                 }
                 builder.Append("                ");
-                for (int firingColumn = 1; firingColumn <= 10; firingColumn++)
+                for (int firingColumn = 1; firingColumn <= PlayBoard.BoardSize; firingColumn++)
                 {
                     builder.Append(FiringBoard.Panels.At(row, firingColumn).Status + " ");
                 }
@@ -80,29 +84,28 @@ namespace GopalBattleship.Entities
                 bool isOpen = true;
                 while (isOpen)
                 {
-                    var startcolumn = random.Next(1,11);
-                    var startrow = random.Next(1, 11);
+                    var startcolumn = random.Next(1, PlayBoard.BoardSize + 1);
+                    var startrow = random.Next(1, PlayBoard.BoardSize + 1);
                     int endrow = startrow, endcolumn = startcolumn;
                     var orientation = random.Next(1, 101) % 2; //0 for Horizontal
 
-                    List<int> panelNumbers = new List<int>();
                     if (orientation == 0)
-                    {
-                        for (int i = 1; i < ship.Width; i++)
-                        {
-                            endrow++;
-                        }
-                    }
-                    else
                     {
                         for (int i = 1; i < ship.Width; i++)
                         {
                             endcolumn++;
                         }
                     }
+                    else
+                    {
+                        for (int i = 1; i < ship.Width; i++)
+                        {
+                            endrow++;
+                        }
+                    }
 
                     //ships should be placed within the boundry.
-                    if(endrow > 10 || endcolumn > 10)
+                    if(endrow > PlayBoard.BoardSize || endcolumn > PlayBoard.BoardSize)
                     {
                         isOpen = true;
                         continue;
@@ -153,9 +156,14 @@ namespace GopalBattleship.Entities
         public ShotResult ProcessShot(Coordinates coords)
         {
             var panel = GameBoard.Panels.At(coords.Row, coords.Column);
+            if (panel.OccupationType.IsShotResult())
+            {
+                throw new InvalidOperationException("Position already targeted");
+            }
             if (!panel.IsOccupied)
             {
                 Console.WriteLine(Name + " says: \"Firing missed!\"");
+                panel.OccupationType = EnumLabel.Miss;
                 return ShotResult.Miss;
             }
             //A battleship is sunk if it has been hit on all the squares it occupies
@@ -163,6 +171,7 @@ namespace GopalBattleship.Entities
             var ship = Ships.First(x => x.OccupationType == panel.OccupationType);
             ship.Hits++;
             Console.WriteLine(Name + " says: \"Firing hit the target!\"");
+            panel.OccupationType = EnumLabel.Hit;
             if (ship.IsSunk)
             {
                 Console.WriteLine(Name + " says: \"You sunk my " + ship.Name + "!\"");

--- a/GopalBattleShip/Entities/Ships/Carrier.cs
+++ b/GopalBattleShip/Entities/Ships/Carrier.cs
@@ -1,0 +1,12 @@
+namespace GopalBattleship.Entities.Ships
+{
+    public class Carrier : Ship
+    {
+        public Carrier()
+        {
+            Name = "Carrier";
+            Width = 5;
+            OccupationType = EnumLabel.Carrier;
+        }
+    }
+}

--- a/GopalBattleShip/Entities/Ships/Cruiser.cs
+++ b/GopalBattleShip/Entities/Ships/Cruiser.cs
@@ -1,0 +1,12 @@
+namespace GopalBattleship.Entities.Ships
+{
+    public class Cruiser : Ship
+    {
+        public Cruiser()
+        {
+            Name = "Cruiser";
+            Width = 3;
+            OccupationType = EnumLabel.Cruiser;
+        }
+    }
+}

--- a/GopalBattleShip/Entities/Ships/Destroyer.cs
+++ b/GopalBattleShip/Entities/Ships/Destroyer.cs
@@ -1,0 +1,12 @@
+namespace GopalBattleship.Entities.Ships
+{
+    public class Destroyer : Ship
+    {
+        public Destroyer()
+        {
+            Name = "Destroyer";
+            Width = 2;
+            OccupationType = EnumLabel.Destroyer;
+        }
+    }
+}

--- a/GopalBattleShip/Entities/Ships/Submarine.cs
+++ b/GopalBattleShip/Entities/Ships/Submarine.cs
@@ -1,0 +1,12 @@
+namespace GopalBattleship.Entities.Ships
+{
+    public class Submarine : Ship
+    {
+        public Submarine()
+        {
+            Name = "Submarine";
+            Width = 3;
+            OccupationType = EnumLabel.Submarine;
+        }
+    }
+}

--- a/GopalBattleShip/EnumObjects.cs
+++ b/GopalBattleShip/EnumObjects.cs
@@ -12,8 +12,20 @@ namespace GopalBattleship
         [Description("O")]
         Empty,
 
+        [Description("C")]
+        Carrier,
+
         [Description("B")]
         Battleship,
+
+        [Description("R")]
+        Cruiser,
+
+        [Description("S")]
+        Submarine,
+
+        [Description("D")]
+        Destroyer,
 
         [Description("H")]
         Hit,

--- a/GopalBattleShip/GopalBattleship.csproj
+++ b/GopalBattleShip/GopalBattleship.csproj
@@ -44,6 +44,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EnumObjects.cs" />
+    <Compile Include="Utilities\EnumLabelExtensions.cs" />
     <Compile Include="Utilities\EnumObjectMapper.cs" />
     <Compile Include="Utilities\Helpers.cs" />
     <Compile Include="Utilities\PanelFixture.cs" />
@@ -53,8 +54,12 @@
     <Compile Include="Entities\Boards\Panel.cs" />
     <Compile Include="Entities\Games\Game.cs" />
     <Compile Include="Entities\Player.cs" />
+    <Compile Include="Entities\Ships\Carrier.cs" />
     <Compile Include="Entities\Ships\Battleship.cs" />
+    <Compile Include="Entities\Ships\Cruiser.cs" />
+    <Compile Include="Entities\Ships\Destroyer.cs" />
     <Compile Include="Entities\Ships\Ship.cs" />
+    <Compile Include="Entities\Ships\Submarine.cs" />
     <Compile Include="Online\OnlineGameServer.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/GopalBattleShip/Online/OnlineGameServer.cs
+++ b/GopalBattleShip/Online/OnlineGameServer.cs
@@ -49,9 +49,21 @@ namespace GopalBattleship.Online
                 {
                     var player1 = request.QueryString["player1"];
                     var player2 = request.QueryString["player2"];
-                    var id = Guid.NewGuid().ToString();
-                    _games[id] = new Game(player1, player2);
-                    payload = id;
+                    if (string.IsNullOrWhiteSpace(player1) || string.IsNullOrWhiteSpace(player2))
+                    {
+                        response.StatusCode = 400;
+                        payload = "Both player names are required.";
+                    }
+                    else
+                    {
+                        var id = Guid.NewGuid().ToString();
+                        _games[id] = new Game(player1, player2);
+                        payload = id;
+                    }
+                }
+                else if (request.Url.AbsolutePath == "/health")
+                {
+                    payload = "OK";
                 }
                 else if (request.Url.AbsolutePath == "/fire")
                 {
@@ -92,6 +104,16 @@ namespace GopalBattleship.Online
                     response.StatusCode = 404;
                     payload = "Unknown endpoint";
                 }
+            }
+            catch (ArgumentException ex)
+            {
+                response.StatusCode = 400;
+                payload = ex.Message;
+            }
+            catch (InvalidOperationException ex)
+            {
+                response.StatusCode = 400;
+                payload = ex.Message;
             }
             catch (Exception ex)
             {

--- a/GopalBattleShip/Program.cs
+++ b/GopalBattleShip/Program.cs
@@ -7,12 +7,32 @@ namespace GopalBattleship
     {
         static void Main(string[] args)
         {
-            var server = new OnlineGameServer("http://localhost:5000/");
+            var prefix = GetPrefix(args);
+            var server = new OnlineGameServer(prefix);
             server.Start();
-            Console.WriteLine("Battleship online server running at http://localhost:5000/");
+            Console.WriteLine($"Battleship online server running at {prefix}");
             Console.WriteLine("Press Enter to stop the server.");
             Console.ReadLine();
             server.Stop();
+        }
+
+        private static string GetPrefix(string[] args)
+        {
+            var prefix = args.Length > 0
+                ? args[0]
+                : Environment.GetEnvironmentVariable("BATTLESHIP_PREFIX");
+
+            if (string.IsNullOrWhiteSpace(prefix))
+            {
+                prefix = "http://localhost:5000/";
+            }
+
+            if (!prefix.EndsWith("/"))
+            {
+                prefix += "/";
+            }
+
+            return prefix;
         }
     }
 }

--- a/GopalBattleShip/Utilities/EnumLabelExtensions.cs
+++ b/GopalBattleShip/Utilities/EnumLabelExtensions.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace GopalBattleship.Utilities
+{
+    public static class EnumLabelExtensions
+    {
+        public static bool IsShip(this EnumLabel label)
+        {
+            switch (label)
+            {
+                case EnumLabel.Carrier:
+                case EnumLabel.Battleship:
+                case EnumLabel.Cruiser:
+                case EnumLabel.Submarine:
+                case EnumLabel.Destroyer:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        public static bool IsShotResult(this EnumLabel label)
+        {
+            return label == EnumLabel.Hit || label == EnumLabel.Miss;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Allow the server to be configured for deployment by accepting a listener prefix from CLI or `BATTLESHIP_PREFIX` and provide a simple readiness endpoint. 
- Replace scattered hardcoded board size values with a single `PlayBoard.BoardSize` to keep placement, neighbor checks, and display consistent. 
- Support a standard fleet and improve gameplay correctness by tracking hit/miss state and preventing invalid actions.

### Description
- Add `GetPrefix` in `Program.cs` to accept a CLI prefix or `BATTLESHIP_PREFIX` environment variable and use it when creating `OnlineGameServer`, and update startup logging to show the chosen prefix. 
- Add a `/health` endpoint and strengthen `/start` request validation in `OnlineGameServer`, and map `ArgumentException` and `InvalidOperationException` to HTTP 400 responses. 
- Introduce new ship classes `Carrier`, `Cruiser`, `Submarine`, and `Destroyer`, add their `EnumLabel` entries, and add `Utilities/EnumLabelExtensions.cs` with `IsShip()` and `IsShotResult()`, then use `IsShip()` in `Panel.IsOccupied`. 
- Centralize board size with `PlayBoard.BoardSize` and update `PlayBoard`, `Player`, `ShootingBoard`, and `Game` to use it for loops, bounds checks, and neighbor calculations, and fix ship placement orientation increments in `Player.PlaceShips`. 
- Harden gameplay validation by marking panels as `Hit`/`Miss` in `Player.ProcessShot`, preventing repeated targeting via `IsShotResult()`, and adding coordinate bounds validation in `Game.FireShot`. 
- Update project file `GopalBattleship.csproj` to include the newly added files.

### Testing
- No automated tests were executed because .NET/Mono tooling was not available in the environment when attempting `dotnet --version`, `msbuild /version`, and `mono --version`. 
- Basic static/manual inspection was performed on modified files to ensure consistent API and constant replacements, but no runtime tests ran due to the missing runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69704f07e9f88331b8aa9aa988cde96e)